### PR TITLE
Fixing iOS podspec for building with Capacitor

### DIFF
--- a/EcnivtwelveCapacitorNavigationBar.podspec
+++ b/EcnivtwelveCapacitorNavigationBar.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name = 'MauricewegnerCapacitorNavigationBar'
+  s.name = 'EcnivtwelveCapacitorNavigationBar'
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']

--- a/MauricewegnerCapacitorNavigationBar.podspec
+++ b/MauricewegnerCapacitorNavigationBar.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name = 'HugotomaziCapacitorNavigationBar'
+  s.name = 'MauricewegnerCapacitorNavigationBar'
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@mauricewegner/capacitor-navigation-bar",
+    "name": "@ecnivtwelve/capacitor-navigation-bar",
     "version": "2.0.1",
     "description": "Capacitor Plugin for Navigation Bar",
     "main": "dist/plugin.cjs.js",
@@ -12,16 +12,16 @@
         "android/build.gradle",
         "dist/",
         "ios/Plugin/",
-        "MauricewegnerCapacitorNavigationBar.podspec"
+        "EcnivtwelveCapacitorNavigationBar.podspec"
     ],
-    "author": "mauricewegner",
+    "author": "ecnivtwelve",
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/mauricewegner/navigation-bar.git"
+        "url": "git+https://github.com/ecnivtwelve/navigation-bar.git"
     },
     "bugs": {
-        "url": "https://github.com/mauricewegner/navigation-bar/issues"
+        "url": "https://github.com/ecnivtwelve/navigation-bar/issues"
     },
     "keywords": [
         "capacitor",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@hugotomazi/capacitor-navigation-bar",
+    "name": "@mauricewegner/capacitor-navigation-bar",
     "version": "2.0.1",
     "description": "Capacitor Plugin for Navigation Bar",
     "main": "dist/plugin.cjs.js",
@@ -12,16 +12,16 @@
         "android/build.gradle",
         "dist/",
         "ios/Plugin/",
-        "HugotomaziCapacitorNavigationBar.podspec"
+        "MauricewegnerCapacitorNavigationBar.podspec"
     ],
-    "author": "hugotomazi",
+    "author": "mauricewegner",
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/hugotomazi/navigation-bar.git"
+        "url": "git+https://github.com/mauricewegner/navigation-bar.git"
     },
     "bugs": {
-        "url": "https://github.com/hugotomazi/navigation-bar/issues"
+        "url": "https://github.com/mauricewegner/navigation-bar/issues"
     },
     "keywords": [
         "capacitor",


### PR DESCRIPTION
Capacitor uses the module name for the Pod name on iOS deploy and because of that, wasn't able to find the modules still named after `hugotomazi/navigation-bar`. Changing the file name fixes that.